### PR TITLE
Replace duplicated code in SudokuUtilities

### DIFF
--- a/src/main/java/com/wissassblog/sudoku/computationlogic/SudokuUtilities.java
+++ b/src/main/java/com/wissassblog/sudoku/computationlogic/SudokuUtilities.java
@@ -26,12 +26,7 @@ public class SudokuUtilities {
      */
     public static int[][] copyToNewArray(int[][] oldArray) {
         int[][] newArray = new int[SudokuGame.GRID_BOUNDARY][SudokuGame.GRID_BOUNDARY];
-        for (int xIndex = 0; xIndex < SudokuGame.GRID_BOUNDARY; xIndex++){
-            for (int yIndex = 0; yIndex < SudokuGame.GRID_BOUNDARY; yIndex++ ){
-                newArray[xIndex][yIndex] = oldArray[xIndex][yIndex];
-            }
-        }
-
+         copySudokuArrayValues(oldArray,newArray);
         return newArray;
     }
 }


### PR DESCRIPTION
Since the two loops seemed practically identical ; I can't think of a reason why we can't just call our already established function.